### PR TITLE
詳細情報の表示

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
+  # before_action :set_prototype, only: [:show]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -19,9 +20,17 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def show
+    @prototype = Prototype.find(params[:id])
+  end
   private
 
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
+
+  # def set_prototype
+  #   @prototype = Prototype.find(params[:id])
+  # end
+
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image.variant(resize: '150x150'), class: :card__img ), root_path %>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype) %>
   <div class="card__body">
-    <%= link_to prototype.title, root_path, class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -14,19 +14,19 @@
       <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag @prototype.image %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= @prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= @prototype.concept %>
           </p>
         </div>
       </div>


### PR DESCRIPTION
#What
プロトタイプ詳細機能実装

#Why
プロトタイプ詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。
プロトタイプ一覧ページにてプロトタイプ情報をクリックすると、該当するプロトタイプの詳細表示ページへ遷移すること。
プロトタイプ投稿時に登録した情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト）が表示されること。
画像が表示されており、画像がリンク切れなどにならないこと。（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）
ログイン状態且つ、自身が投稿した場合にのみ、「編集する」「削除する」ボタンが表示されること。
ログイン状態の場合でも、自身が投稿していない場合は、「編集する」「削除する」ボタンが表示されないこと。
ログアウト状態の場合では、「編集する」「削除する」ボタンが表示されないこと。
