### PR TITLE
プロトタイプのタイトルを表示する

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.title %>
       </p>
       <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user), class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>


### PR DESCRIPTION
# What
プロトタイプ詳細ページで、プロトタイプのタイトルを表示する

# Why
プロトタイプのタイトルを表示する実装が漏れていたため

※動作確認は現場で実施したため、gyazoのURLは添付しない